### PR TITLE
Fixes for AOT compilation for iOS.

### DIFF
--- a/Zip Reduced/Zip Reduced.csproj
+++ b/Zip Reduced/Zip Reduced.csproj
@@ -45,7 +45,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;AESCRYPTO;BZIP;SILVERLIGHT;NO_LINQ</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;AESCRYPTO;BZIP;SILVERLIGHT;NO_LINQ;NO_SFX</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Ionic.Zip.Unity.XML</DocumentationFile>
@@ -55,7 +55,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;AESCRYPTO;BZIP;SILVERLIGHT;NO_LINQ</DefineConstants>
+    <DefineConstants>TRACE;AESCRYPTO;BZIP;SILVERLIGHT;NO_LINQ;NO_SFX</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>

--- a/Zip/WinZipAes.cs
+++ b/Zip/WinZipAes.cs
@@ -928,10 +928,14 @@ namespace Ionic.Zip
             lock(_outputLock)
             {
                 int tid = System.Threading.Thread.CurrentThread.GetHashCode();
+#if !(NETCF || SILVERLIGHT)
                 Console.ForegroundColor = (ConsoleColor) (tid % 8 + 8);
+#endif
                 Console.Write("{0:000} WZACS ", tid);
                 Console.WriteLine(format, varParams);
+#if !(NETCF || SILVERLIGHT)
                 Console.ResetColor();
+#endif
             }
         }
 

--- a/Zip/ZipEntry.Write.cs
+++ b/Zip/ZipEntry.Write.cs
@@ -73,7 +73,7 @@ namespace Ionic.Zip
 
             // workitem 11969: Version Needed To Extract in central directory must be
             // the same as the local entry or MS .NET System.IO.Zip fails read.
-            Int16 vNeeded = (Int16)(VersionNeeded != 0 ? VersionNeeded : 20);
+            Int16 vNeeded = (Int16)(VersionNeeded != 0 ? VersionNeeded : (short)20);
             // workitem 12964
             if (_OutputUsesZip64==null)
             {
@@ -81,7 +81,7 @@ namespace Ionic.Zip
                 _OutputUsesZip64 = new Nullable<bool>(_container.Zip64 == Zip64Option.Always);
             }
 
-            Int16 versionNeededToExtract = (Int16)(_OutputUsesZip64.Value ? 45 : vNeeded);
+            Int16 versionNeededToExtract = (Int16)(_OutputUsesZip64.Value ? (short)45 : vNeeded);
 #if BZIP
             if (this.CompressionMethod == Ionic.Zip.CompressionMethod.BZip2)
                 versionNeededToExtract = 46;


### PR DESCRIPTION
These changes make it possible to use the library in Unity iOS with API Compatibility set to .NET 2.0 Subset.  I have not changed the compiled binaries.
